### PR TITLE
Allow selector to be keyword or symbol.

### DIFF
--- a/src/moria/core.cljs
+++ b/src/moria/core.cljs
@@ -7,11 +7,11 @@
 
 (defn m
   ([selector]
-   (js/m selector))
+   (js/m (name selector)))
   ([selector attr]
-   (js/m selector (clj->js attr)))
+   (js/m (name selector) (clj->js attr)))
   ([selector attr & children]
-   (js/m selector (clj->js attr) (clj->js children))))
+   (js/m (name selector) (clj->js attr) (clj->js children))))
 
 (defn render
   [element vnodes]


### PR DESCRIPTION
In addition to string type.

So you can do:

```clojure
(m :div {:class "foo"} "Hello")
(m 'div {:class "foo"} "Hello")
```